### PR TITLE
feat(auth): add secure storage for authentication tokens

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,10 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -26,6 +29,16 @@
       "favicon": "./assets/favicon.png",
       "bundler": "metro"
     },
-    "plugins": ["expo-router"]
+    "plugins": [
+      "expo-router",
+      "expo-secure-store",
+      [
+        "expo-secure-store",
+        {
+          "configureAndroidBackup": true,
+          "faceIDPermission": "Allow $(PRODUCT_NAME) to access your Face ID biometric data."
+        }
+      ]
+    ]
   }
 }

--- a/enum.ts
+++ b/enum.ts
@@ -1,3 +1,7 @@
 export enum ENV {
   EXPO_PUBLIC_API_URL = 'EXPO_PUBLIC_API_URL'
 }
+
+export enum SECURE_STORE_KEY {
+  AUTH = 'AUTH'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^14.0.2",
         "expo": "52.0.42",
         "expo-router": "4.0.20",
+        "expo-secure-store": "~14.0.1",
         "expo-status-bar": "2.0.1",
         "formik": "2.4.6",
         "nativewind": "4.1.23",
@@ -7594,6 +7595,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.1.tgz",
+      "integrity": "sha512-QUS+j4+UG4jRQalgnpmTvvrFnMVLqPiUZRzYPnG3+JrZ5kwVW2w6YS3WWerPoR7C6g3y/a2htRxRSylsDs+TaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^14.0.2",
     "expo": "52.0.42",
     "expo-router": "4.0.20",
     "expo-status-bar": "2.0.1",
@@ -20,7 +21,7 @@
     "react-native-safe-area-context": "5.3.0",
     "tailwindcss": "3.4.17",
     "yup": "1.6.1",
-    "@expo/vector-icons": "^14.0.2"
+    "expo-secure-store": "~14.0.1"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",

--- a/screens/auth/register.screen.tsx
+++ b/screens/auth/register.screen.tsx
@@ -12,11 +12,13 @@ import {
   Platform,
   Keyboard
 } from 'react-native'
-import { Register, RegisterFormik } from '../../type'
+import { Login, Register, RegisterFormik } from '../../type'
 import { Formik } from 'formik'
 import { Ionicons } from '@expo/vector-icons'
 import { registerValidation } from '../../validation.schema'
 import { fetchData } from '../../utils/fetchData.util'
+import { setKeychain } from '../../utils/keychain.util'
+import { SECURE_STORE_KEY } from '../../enum'
 
 const RegisterScreen: FC = () => {
   const [initialValues] = useState<RegisterFormik>({
@@ -57,6 +59,34 @@ const RegisterScreen: FC = () => {
     ]).start()
   }, [])
 
+  const handlerLogin = async (
+    email: string,
+    password: string
+  ): Promise<void> => {
+    try {
+      const data = await fetchData<Login>(
+        '/auth/login',
+        {
+          email,
+          password
+        },
+        'POST'
+      )
+      if (data.message !== undefined) {
+        setError(data.message)
+      } else {
+        setError('')
+        data.token !== undefined &&
+          (await setKeychain(SECURE_STORE_KEY.AUTH, {
+            token: data.token,
+            user: data.user
+          }))
+      }
+    } catch (error) {
+      setError('Error al iniciar sesión')
+    }
+  }
+
   const handleRegister = async (value: RegisterFormik): Promise<void> => {
     Keyboard.dismiss()
     const { name, email, password } = value
@@ -74,6 +104,7 @@ const RegisterScreen: FC = () => {
         setError(data.message)
       } else {
         setError('')
+        await handlerLogin(email, password)
         router.push('/')
       }
     } catch (error) {

--- a/type.d.ts
+++ b/type.d.ts
@@ -19,3 +19,17 @@ export interface RegisterFormik {
 }
 
 export type METHOD = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+
+export interface Login extends Res {
+  user?: User
+  token?: string
+}
+
+export interface User {
+  name?: string
+  email?: string
+  role?: string
+  createdAt?: Date
+  updatedAt?: Date
+  id?: string
+}

--- a/utils/keychain.util.ts
+++ b/utils/keychain.util.ts
@@ -1,0 +1,35 @@
+import { SECURE_STORE_KEY } from '../enum'
+import { Login } from '../type'
+import * as SecureStore from 'expo-secure-store'
+
+export const setKeychain = async (
+  key: SECURE_STORE_KEY,
+  data: Login
+): Promise<void> => {
+  try {
+    await SecureStore.setItemAsync(key, JSON.stringify(data))
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(error.message)
+      throw new Error(error.message)
+    }
+  }
+}
+
+export const getKeychain = async (
+  key: SECURE_STORE_KEY
+): Promise<Login | null> => {
+  try {
+    const credentials = await SecureStore.getItemAsync(key)
+    if (credentials !== null) {
+      return JSON.parse(credentials)
+    }
+    return null
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(error.message)
+      throw new Error(error.message)
+    }
+    return null
+  }
+}


### PR DESCRIPTION
Introduce expo-secure-store to securely store authentication tokens and user data. Add new utility functions for keychain management and integrate them into the registration flow. This ensures sensitive data is securely persisted across app sessions.