### PR TITLE
Feature/price

### DIFF
--- a/components/screen/card/card.screen.component.tsx
+++ b/components/screen/card/card.screen.component.tsx
@@ -3,6 +3,7 @@ import { FC, useState } from 'react'
 import { View, Image, Text, Pressable } from 'react-native'
 import { CardScreenComponentProps } from '../../../type'
 import ModalCardComponent from './components/modal.card.component'
+import { formatChileanPesos } from '../../../utils/price.util'
 
 const CardScreenComponent: FC<CardScreenComponentProps> = (props) => {
   const [modalVisible, setModalVisible] = useState(false)
@@ -39,7 +40,7 @@ const CardScreenComponent: FC<CardScreenComponentProps> = (props) => {
 
           <View className='flex-row justify-between items-center'>
             <Text className='text-xl font-bold text-primary-500'>
-              ${props.price}
+              {formatChileanPesos(props.price)}
             </Text>
             <Pressable
               className='bg-primary-500 w-10 h-10 rounded-full items-center justify-center'

--- a/components/screen/card/components/modal.card.component.tsx
+++ b/components/screen/card/components/modal.card.component.tsx
@@ -8,6 +8,7 @@ import { SECURE_STORE_KEY } from '../../../../enum'
 import Toast, { BaseToast } from 'react-native-toast-message'
 import { useAppDispatch } from '../../../../redux/hooks'
 import { amount, increment } from '../../../../redux/cart/cart.slice'
+import { formatChileanPesos } from '../../../../utils/price.util'
 
 const ModalCardComponent: FC<ModalCardComponentProps> = ({
   id,
@@ -175,15 +176,16 @@ const ModalCardComponent: FC<ModalCardComponentProps> = ({
               <View className='flex-row items-center justify-between'>
                 <View>
                   <Text className='text-2xl font-bold text-primary-500'>
-                    ${price * quantity}
+                    {formatChileanPesos(price * quantity)}
                   </Text>
                   {selectedExtras.length > 0 && (
                     <Text className='text-sm text-primary-400'>
-                      +$
-                      {ingredientsExtra
-                        .filter((ing) => selectedExtras.includes(ing.name))
-                        .reduce((sum, ing) => sum + ing.price, 0) *
-                        quantity}{' '}
+                      +
+                      {formatChileanPesos(
+                        ingredientsExtra
+                          .filter((ing) => selectedExtras.includes(ing.name))
+                          .reduce((sum, ing) => sum + ing.price, 0) * quantity
+                      )}{' '}
                       extras
                     </Text>
                   )}
@@ -299,7 +301,7 @@ const ModalCardComponent: FC<ModalCardComponentProps> = ({
                           isSelected ? 'text-white' : 'text-primary-600'
                         }`}
                       >
-                        +${ingredient.price}
+                        +{formatChileanPesos(ingredient.price)}
                       </Text>
                     </Pressable>
                   )
@@ -329,7 +331,8 @@ const ModalCardComponent: FC<ModalCardComponentProps> = ({
               }}
             >
               <Text className='text-white font-bold text-lg'>
-                Agregar {quantity} al carrito - ${calculateTotal()}
+                Agregar {quantity} al carrito -{' '}
+                {formatChileanPesos(calculateTotal())}
               </Text>
             </Pressable>
           </View>

--- a/components/screen/cart/components/card.screen.component.tsx
+++ b/components/screen/cart/components/card.screen.component.tsx
@@ -7,6 +7,7 @@ import { getKeychain } from '../../../../utils/keychain.util'
 import { SECURE_STORE_KEY } from '../../../../enum'
 import { decrement, setTotal } from '../../../../redux/cart/cart.slice'
 import { useAppDispatch } from '../../../../redux/hooks'
+import { formatChileanPesos } from '../../../../utils/price.util'
 
 const RenderItem: FC<RenderItemProps> = ({
   item,
@@ -96,11 +97,11 @@ const RenderItem: FC<RenderItemProps> = ({
           {item.product.name}
         </Text>
         <Text className='text-primary-700 font-bold text-base'>
-          ${item.price}
+          {formatChileanPesos(item.price)}
         </Text>
         {item.extra > 0 && (
           <Text className='text-sm text-primary-400'>
-            +${item.extra} extras
+            +{formatChileanPesos(item.extra)} extras
           </Text>
         )}
         {item.ingredients !== undefined && item.ingredients.length > 0 && (
@@ -116,7 +117,7 @@ const RenderItem: FC<RenderItemProps> = ({
             // eslint-disable-next-line @typescript-eslint/indent
           )}
         <Text className='text-secondary-600 text-sm mt-1'>
-          Subtotal: ${subTotal}
+          Subtotal: {formatChileanPesos(subTotal)}
         </Text>
         <View className='flex-row items-center mt-2'>
           <Pressable

--- a/screens/home/cart.screen.tsx
+++ b/screens/home/cart.screen.tsx
@@ -6,6 +6,7 @@ import { CartItem } from '../../type'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import EmptyCart from '../../components/screen/cart/components/emptyCart.screen.component'
 import { setTotal } from '../../redux/cart/cart.slice'
+import { formatChileanPesos } from '../../utils/price.util'
 
 const CartScreen: FC = () => {
   const cartItemsCount = useAppSelector((state) => state.cart.value)
@@ -57,7 +58,9 @@ const CartScreen: FC = () => {
         <View className='bg-white p-4 shadow-lg'>
           <View className='flex-row justify-between items-center mb-4'>
             <Text className='text-secondary-600 text-lg'>Total:</Text>
-            <Text className='text-primary-700 text-xl font-bold'>${total}</Text>
+            <Text className='text-primary-700 text-xl font-bold'>
+              {formatChileanPesos(total)}
+            </Text>
           </View>
           <Pressable
             disabled={disabled}

--- a/utils/price.util.ts
+++ b/utils/price.util.ts
@@ -1,0 +1,8 @@
+export const formatChileanPesos = (amount: number): string => {
+  return new Intl.NumberFormat('es-CL', {
+    style: 'currency',
+    currency: 'CLP',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+  }).format(amount)
+}


### PR DESCRIPTION
Introduce a new utility function `formatChileanPesos` to format numbers as Chilean pesos (CLP) using `Intl.NumberFormat`. This utility is applied across various components to ensure consistent and localized price display. The change improves user experience by presenting prices in a familiar and standardized format.